### PR TITLE
[add]news scroll bar(#99)

### DIFF
--- a/src/components/common/News/News.module.css
+++ b/src/components/common/News/News.module.css
@@ -17,6 +17,7 @@
   width: 300px;
   height: 670px;
   background: #FFFFFF;
+  overflow: scroll;
 }
 
 .center {
@@ -138,6 +139,11 @@
   font-size: 1.8rem;
   line-height: 5.0rem;
   color: red;
+}
+
+.news {
+  height: 300px;
+  overflow: scroll;
 }
 
 @media screen and (min-width: 720px) and (max-width:960px) {
@@ -267,6 +273,7 @@
     width: 70rem;
     height: 125rem;
     background: #FFFFFF;
+    overflow: scroll;
   }
 
   .card span {


### PR DESCRIPTION
- スマホ版イメージ（スクロールの動作確認のために、8/22のお知らせを追加しました）
<img width="313" alt="スクリーンショット 2022-09-09 8 38 36" src="https://user-images.githubusercontent.com/71711872/189243926-7e3d1ffe-450a-4e5f-8c0c-9fb153e93d93.png">

- PC版イメージ（スクロールの動作確認のために、8/22のお知らせを追加しました）
<img width="1440" alt="スクリーンショット 2022-09-09 8 39 06" src="https://user-images.githubusercontent.com/71711872/189243959-bfe16805-63a7-4471-adc4-7355a8b2c7b6.png">
